### PR TITLE
Use JSON.stringify to produce valid JSON

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -198,7 +198,7 @@ module SurveyEditor {
         }
         private getSurveyTextFromDesigner() {
             var json = new Survey.JsonObject().toJsonObject(this.survey);
-            return new SurveyJSON5().stringify(json, null, 1);
+            return JSON.stringify(json, null, 1);
         }
         private selectedObjectChanged(obj: Survey.Base) {
             var canDeleteObject = false;


### PR DESCRIPTION
Users should be able to copy/paste JSON from or into the JSON-Editor tab. Therefore the JSON produced by the editor should be valid.